### PR TITLE
[JIB] JIB 설정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # az-backend
+
+로컬에서 이미지 빌드 방법
+
+```bash
+./gradlew jibDockerBuild -Djib.dockerClient.executable=$(which podman)
+```
+
+docker 를 사용하시면 뒤에 -Djib 옵션을 제거하셔도 됩니다
+
+which podman 부분에는 여러분이 사용하는 docker image builder 이름을 넣어주세요

--- a/build.gradle
+++ b/build.gradle
@@ -1,54 +1,75 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.0.4'
-	id 'io.spring.dependency-management' version '1.1.0'
-	id 'org.asciidoctor.convert' version '2.4.0'
-	id 'com.google.cloud.tools.jib' version '3.3.1'
+    id 'java'
+    id 'org.springframework.boot' version '3.0.4'
+    id 'io.spring.dependency-management' version '1.1.0'
+    id 'org.asciidoctor.convert' version '2.4.0'
+    id 'com.google.cloud.tools.jib' version '3.3.1'
 }
 
 group = 'com.studio-playground'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
+
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('snippetsDir', file("build/generated-snippets"))
+    set('snippetsDir', file("build/generated-snippets"))
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.kafka:kafka-streams'
-	implementation 'org.flywaydb:flyway-core'
-	implementation 'org.flywaydb:flyway-mysql'
-	implementation 'org.springframework.kafka:spring-kafka'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.kafka:spring-kafka-test'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.apache.kafka:kafka-streams'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
+    implementation 'org.springframework.kafka:spring-kafka'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 tasks.named('test') {
-	outputs.dir snippetsDir
-	useJUnitPlatform()
+    outputs.dir snippetsDir
+    useJUnitPlatform()
 }
 
 tasks.named('asciidoctor') {
-	inputs.dir snippetsDir
-	dependsOn test
+    inputs.dir snippetsDir
+    dependsOn test
+}
+
+jib {
+    from {
+        image = "eclipse-temurin:17.0.6_10-jre"
+        platforms {
+            platform {
+                architecture = 'arm64'
+                os = 'linux'
+            }
+        }
+    }
+    to {
+        image = 'az-backend'
+        tags = ('production' == System.getenv("ENV")) ? ["${version}"] : ['latest']
+    }
+    container {
+        ports = ['8080']
+        format = 'OCI'
+    }
 }


### PR DESCRIPTION
탬플릿 아직 없어서 대충 적어요

## JIB 란

docker image 등을 만들때 dockerfile 없이 최적화된 docker image 를 만들어줌

## 기본 적인 사용법

build.gradle 에 플러그인을 추가한 후

```groovy
plugins {
  //...
    id 'com.google.cloud.tools.jib' version '3.3.1'
}
```

jib 부분을 추가하면 끝납니다

```groovy
jib {
  //...
}
```

jib 부분이 없어도 실행시 변수를 줘서 할수도 있는거 같습니다

자세한 부분을 링크 참조

https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin

## 추가적으로 설정한 부분

### From

#### 이미지버전

먼저 처음에는 `eclipse-temurin:17.0.6_10-jre-alpine` 로 했는데 arm64 가 없더라고요 그래서 어쩔수 없이 `eclipse-temurin:17.0.6_10-jre` 로 설정을 했습니다.

용량은 아래와 같이 차이가 나요

| 이미지 버전                          | 용량     |
| ------------------------------------ | -------- |
| eclipse-temurin:17.0.6_10-jre        | 88.89 MB |
| eclipse-temurin:17.0.6_10-jre-alpine | 59.22 MB |

이정도면 그냥 사용해도 되지 않을까 싶습니다

#### paltforms

로컬은 arm64 인데 계속 amd64로 이미지가 말아지더라고요 기본설정이 그렇게 되는거 같아서 따로 설정을 했습니다

```groovy
    from {
        image = "eclipse-temurin:17.0.6_10-jre"
        platforms {
            platform {
                architecture = 'arm64'
                os = 'linux'
            }
        }
    }
```

### To

image 에 저장될 위치를 포함해야되는데 아직 없어서 이름만 적어 놨습니다.

tag 에 환경에 따라 다른 tag 로 말아지게 설정했어요

### Conainer

port 설정과 format 을 통해 OCI 표준 컨테이너 형식을 준수하게 했습니다

