### PR TITLE
:sparkles: BaseJPAEntity 추가

### DIFF
--- a/src/main/java/com/studioplayground/azbackend/common/infrastructure/adapter/out/persistence/model/BaseJpaEntity.java
+++ b/src/main/java/com/studioplayground/azbackend/common/infrastructure/adapter/out/persistence/model/BaseJpaEntity.java
@@ -1,0 +1,48 @@
+package com.studioplayground.azbackend.common.infrastructure.adapter.out.persistence.model;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@SuperBuilder
+@MappedSuperclass
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseJpaEntity {
+
+    @NotNull
+    @Column
+    @CreatedBy
+    private String createdBy;
+
+    @NotNull
+    @Column
+    @LastModifiedBy
+    private String modifiedBy;
+
+    @NotNull
+    @Column
+    @CreatedDate
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime createdDateTime;
+
+    @NotNull
+    @Column
+    @LastModifiedDate
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime modifiedDateTime;
+}


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?  
  
- Domain Entity들에 중복으로 필요한 Mysql System 필드 관련 Entity가 필요함  
  
# 어떻게 해결했나요?
  
- `springframework.data.annotation`에서 제공되는 annotation명을 기준으로 필드명 생성   
     - 생성 : create
     - 수정 : modify
  
- 총 4개 필드 추가(생성자, 수정자, 생성시간, 수정시간)  
  
# Attachment. 

