### PR TITLE
✨ api 응답 형식 정의

### DIFF
--- a/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/ApiErrorCode.java
+++ b/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/ApiErrorCode.java
@@ -1,6 +1,8 @@
 package com.studioplayground.azbackend.infrastructure.adapter.in.rest.model;
 
-public interface ErrorCode {
+public interface ApiErrorCode {
+
     int getCode();
+
     int getMessage();
 }

--- a/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/ApiResponse.java
+++ b/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/ApiResponse.java
@@ -1,6 +1,9 @@
 package com.studioplayground.azbackend.infrastructure.adapter.in.rest.model;
 
-public interface ApiResponse {
+public sealed interface ApiResponse permits SuccessResponse, FailResponse {
+    String DEFAULT_API_VERSION = "1.0.0";
+
     String getApiVersion();
+    String getDomain();
     boolean isSuccess();
 }

--- a/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/ApiResponse.java
+++ b/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/ApiResponse.java
@@ -1,0 +1,6 @@
+package com.studioplayground.azbackend.infrastructure.adapter.in.rest.model;
+
+public interface ApiResponse {
+    String getApiVersion();
+    boolean isSuccess();
+}

--- a/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/ErrorCode.java
+++ b/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/ErrorCode.java
@@ -1,0 +1,12 @@
+package com.studioplayground.azbackend.infrastructure.adapter.in.rest.model;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ErrorCode {
+    UNKNOWN_ERROR(9999, "Unknown Error")
+    ;
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/ErrorCode.java
+++ b/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/ErrorCode.java
@@ -1,12 +1,6 @@
 package com.studioplayground.azbackend.infrastructure.adapter.in.rest.model;
 
-import lombok.RequiredArgsConstructor;
-
-@RequiredArgsConstructor
-public enum ErrorCode {
-    UNKNOWN_ERROR(9999, "Unknown Error")
-    ;
-
-    private final int code;
-    private final String message;
+public interface ErrorCode {
+    int getCode();
+    int getMessage();
 }

--- a/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/FailResponse.java
+++ b/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/FailResponse.java
@@ -1,0 +1,29 @@
+package com.studioplayground.azbackend.infrastructure.adapter.in.rest.model;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class FailResponse implements ApiResponse {
+    private static final FailResponse EMPTY_FAIL_RESPONSE = of(ErrorCode.UNKNOWN_ERROR, "");
+
+    private final String apiVersion;
+    private final boolean success = false;
+
+    private final ErrorCode errorCode;
+    private final String message;
+
+    public static FailResponse of(ErrorCode errorCode, String message) {
+        return FailResponse.builder()
+            .apiVersion("1.0.0")
+            .errorCode(errorCode)
+            .message(message)
+            .build();
+    }
+
+    public static FailResponse fail() {
+        return EMPTY_FAIL_RESPONSE;
+    }
+}

--- a/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/FailResponse.java
+++ b/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/FailResponse.java
@@ -6,9 +6,7 @@ import lombok.Getter;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
-public class FailResponse implements ApiResponse {
-    private static final FailResponse EMPTY_FAIL_RESPONSE = of(ErrorCode.UNKNOWN_ERROR, "");
-
+public non-sealed abstract class FailResponse implements ApiResponse {
     private final String apiVersion;
     private final boolean success = false;
 
@@ -17,13 +15,9 @@ public class FailResponse implements ApiResponse {
 
     public static FailResponse of(ErrorCode errorCode, String message) {
         return FailResponse.builder()
-            .apiVersion("1.0.0")
+            .apiVersion(DEFAULT_API_VERSION)
             .errorCode(errorCode)
             .message(message)
             .build();
-    }
-
-    public static FailResponse fail() {
-        return EMPTY_FAIL_RESPONSE;
     }
 }

--- a/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/FailResponse.java
+++ b/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/FailResponse.java
@@ -7,13 +7,17 @@ import lombok.Getter;
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
 public non-sealed abstract class FailResponse implements ApiResponse {
-    private final String apiVersion;
-    private final boolean success = false;
 
-    private final ErrorCode errorCode;
+    private final String apiVersion;
+    private final ApiErrorCode errorCode;
     private final String message;
 
-    public static FailResponse of(ErrorCode errorCode, String message) {
+    @Override
+    public boolean isSuccess() {
+        return false;
+    }
+
+    public static FailResponse of(ApiErrorCode errorCode, String message) {
         return FailResponse.builder()
             .apiVersion(DEFAULT_API_VERSION)
             .errorCode(errorCode)

--- a/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/SuccessResponse.java
+++ b/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/SuccessResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
-public class SuccessResponse<T> implements ApiResponse {
+public non-sealed abstract class SuccessResponse<T> implements ApiResponse {
     private static final SuccessResponse<Object> EMPTY_SUCCESS_RESPONSE = of(null);
 
     private final String apiVersion;
@@ -15,7 +15,7 @@ public class SuccessResponse<T> implements ApiResponse {
     private final T result;
 
     public static <T> SuccessResponse<T> of(final T result) {
-        return of("1.0.0", result);
+        return of(DEFAULT_API_VERSION, result);
     }
 
     public static <T> SuccessResponse<T> of(final String apiVersion, final T result) {

--- a/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/SuccessResponse.java
+++ b/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/SuccessResponse.java
@@ -7,25 +7,27 @@ import lombok.Getter;
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
 public non-sealed abstract class SuccessResponse<T> implements ApiResponse {
-    private static final SuccessResponse<Object> EMPTY_SUCCESS_RESPONSE = of(null);
+
+    private static final SuccessResponse<?> EMPTY_SUCCESS_RESPONSE = of(null);
 
     private final String apiVersion;
-    private final boolean success = true;
 
     private final T result;
+
+    @Override
+    public boolean isSuccess() {
+        return true;
+    }
 
     public static <T> SuccessResponse<T> of(final T result) {
         return of(DEFAULT_API_VERSION, result);
     }
 
     public static <T> SuccessResponse<T> of(final String apiVersion, final T result) {
-        return SuccessResponse.<T>builder()
-            .apiVersion(apiVersion)
-            .result(result)
-            .build();
+        return SuccessResponse.<T>builder().apiVersion(apiVersion).result(result).build();
     }
 
-    public static SuccessResponse<Object> success() {
+    public static SuccessResponse<?> success() {
         return EMPTY_SUCCESS_RESPONSE;
     }
 }

--- a/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/SuccessResponse.java
+++ b/src/main/java/com/studioplayground/azbackend/infrastructure/adapter/in/rest/model/SuccessResponse.java
@@ -1,0 +1,31 @@
+package com.studioplayground.azbackend.infrastructure.adapter.in.rest.model;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class SuccessResponse<T> implements ApiResponse {
+    private static final SuccessResponse<Object> EMPTY_SUCCESS_RESPONSE = of(null);
+
+    private final String apiVersion;
+    private final boolean success = true;
+
+    private final T result;
+
+    public static <T> SuccessResponse<T> of(final T result) {
+        return of("1.0.0", result);
+    }
+
+    public static <T> SuccessResponse<T> of(final String apiVersion, final T result) {
+        return SuccessResponse.<T>builder()
+            .apiVersion(apiVersion)
+            .result(result)
+            .build();
+    }
+
+    public static SuccessResponse<Object> success() {
+        return EMPTY_SUCCESS_RESPONSE;
+    }
+}


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
- api 응답의 형식을 공통으로 정의할 필요가 있습니다

# 어떻게 해결했나요?
- `ApiResponse` 인터페이스와 이를 구현하는 abstract class `SuccessResponse`, `FailResponse` 를 만들어서 성공, 실패 응답의 공통 형식을 만들었습니다
- 각 도메인에서 `SuccessResponse`, `FailResponse` 를 상속받아서 해당 도메인 네임을 내려줘서 어떤 도메인의 응답인지 알려줄 수 있습니다
- `ErrorCode` 인터페이스 또한 각 도메인에서 `Enum` 으로 상속받아서 관리합니다

## Attachment
- 