### PR TITLE
:busts_in_silhouette: AzitException 생성자 추가

### DIFF
--- a/src/main/java/com/studioplayground/azbackend/common/exception/AzitException.java
+++ b/src/main/java/com/studioplayground/azbackend/common/exception/AzitException.java
@@ -16,4 +16,9 @@ public sealed class AzitException extends RuntimeException permits BusinessExcep
         super(e);
         this.message = message;
     }
+
+    public AzitException(String message) {
+        super(message);
+        this.message = message;
+    }
 }

--- a/src/main/java/com/studioplayground/azbackend/common/exception/BusinessException.java
+++ b/src/main/java/com/studioplayground/azbackend/common/exception/BusinessException.java
@@ -11,4 +11,8 @@ public final class BusinessException extends AzitException {
     public BusinessException(Throwable e, String message) {
         super(e, message);
     }
+
+    public BusinessException(String message) {
+        super(message);
+    }
 }


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
- `AzitException, BusinessException` 등 CustomException에 Parameter로 message만 받은 생성자가 없음
    - 매번 Exception 생성할 때 마다 기존 Java Exception을 Parameter로 넘겨줘야함

# 어떻게 해결했나요?
- `AzitException(String message)` 형태의 생성자 추가

## Attachment
- 